### PR TITLE
Fixed Google Single test

### DIFF
--- a/tests/acceptance/SingleCept.php
+++ b/tests/acceptance/SingleCept.php
@@ -4,6 +4,6 @@
   $I->wantTo('Test Google\'s Search Functionality');
   $I->amOnPage('/ncr');
   $I->fillField('q', 'BrowserStack');
-  $I->click('btnG');
+  $I->pressKey('#lst-ib', WebDriverKeys::ENTER);
   $I->seeInTitle('BrowserStack - Google Search');
 ?>


### PR DESCRIPTION
Google's search has a drop-down that is automatically triggered when searching, with suggestions.
That drop-down hides the 'btnG' button so the test outputs an error saying that the element is not visible.

I tried to select the first Google's suggested element, but the suggestion is all lowercase, so the "seeInTitle" fails (unless is also changed...).
I also tried to use the same selector (element's name q) instead of the id #lst-ib for clarity but it doesn't work.

If you want to keep the click function for demonstrative purposes, a solution is to press the ESCAPE key in order to close the drop-down and then click on btnG.